### PR TITLE
Added try-except around getgpu so the function does not crash on non-gpu hosts

### DIFF
--- a/GPUtil/GPUtil.py
+++ b/GPUtil/GPUtil.py
@@ -61,7 +61,10 @@ def safeFloatCast(strNumber):
 
 def getGPUs():
     # Get ID, processing and memory utilization for all GPUs
-    p = Popen(["nvidia-smi","--query-gpu=index,uuid,utilization.gpu,memory.total,memory.used,memory.free,driver_version,name,gpu_serial,display_active,display_mode", "--format=csv,noheader,nounits"], stdout=PIPE)
+    try:
+        p = Popen(["nvidia-smi","--query-gpu=index,uuid,utilization.gpu,memory.total,memory.used,memory.free,driver_version,name,gpu_serial,display_active,display_mode", "--format=csv,noheader,nounits"], stdout=PIPE)
+    except:
+        return []
     output = p.stdout.read().decode('UTF-8')
     # output = output[2:-1] # Remove b' and ' from string added by python
     #print(output)


### PR DESCRIPTION
I am writing unit test on some deep learning code that might run on cpu-only hosts. Currently all functions crash if you run them on a host without nvidia-smi. With this change the function returns an empty array instead of crash.