### PR TITLE
Avoid deadlock when reading stdout of subprocess

### DIFF
--- a/GPUtil/GPUtil.py
+++ b/GPUtil/GPUtil.py
@@ -62,7 +62,8 @@ def safeFloatCast(strNumber):
 def getGPUs():
     # Get ID, processing and memory utilization for all GPUs
     p = Popen(["nvidia-smi","--query-gpu=index,uuid,utilization.gpu,memory.total,memory.used,memory.free,driver_version,name,gpu_serial,display_active,display_mode", "--format=csv,noheader,nounits"], stdout=PIPE)
-    output = p.stdout.read().decode('UTF-8')
+    stdout, stderror = p.communicate()
+    output = stdout.read().decode('UTF-8')
     # output = output[2:-1] # Remove b' and ' from string added by python
     #print(output)
     ## Parse output


### PR DESCRIPTION
https://docs.python.org/2/library/subprocess.html
Do not use stdout=PIPE or stderr=PIPE with this function as that can deadlock based on the child process output volume. Use Popen with the communicate() method when you need pipes.