### PR TITLE
Fix attrList no-effect issue

### DIFF
--- a/GPUtil/GPUtil.py
+++ b/GPUtil/GPUtil.py
@@ -234,7 +234,8 @@ def showUtilization(all=False, attrList=None, useOldCode=False):
             print('--------------')
             for gpu in GPUs:
                 print(' {0:2d} {1:3.0f}% {2:3.0f}%'.format(gpu.id, gpu.load*100, gpu.memoryUtil*100))
-        else:
+        elif attrList is None:
+            # if `attrList` was not specified, use the default one
             attrList = [[{'attr':'id','name':'ID'},
                          {'attr':'load','name':'GPU','suffix':'%','transform': lambda x: x*100,'precision':0},
                          {'attr':'memoryUtil','name':'MEM','suffix':'%','transform': lambda x: x*100,'precision':0}],


### PR DESCRIPTION
In `showUtilization` function, the `attrList` will have no effect with the default setting `all=False` and `useOldCode=False`. The proposed change fixes this issue by checking whether `attrList` was specified in input args (i.e., not `None`).

The proposed change in the other PR (#22) on this issue may lead to no output with the default input args(i.e., if user runs `showUtilization()` there will be no output, whereas it should output the default attributes). 