### PR TITLE
include LICENSE.txt in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license_file = LICENSE.txt


### PR DESCRIPTION
The MIT license "shall be included in all copies or substantial portions of the Software", but you're currently not including it in your `sdist` or `bdist_wheel` files. The `MANIFEST.in` puts it in `sdist`s, and `setup.cfg` for wheels.