### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 license_file = LICENSE.txt


### PR DESCRIPTION
[setuptools >= 0.78 fails with keywords containing `-`](https://setuptools.pypa.io/en/latest/history.html#deprecations-and-removals)

Any project using this library will fail the moment 0.78 becomes the "imported" setuptools version.