### PR TITLE
Ensure that nvidia-smi call succeeded

### DIFF
--- a/GPUtil/GPUtil.py
+++ b/GPUtil/GPUtil.py
@@ -80,6 +80,8 @@ def getGPUs():
     try:
         p = Popen([nvidia_smi,"--query-gpu=index,uuid,utilization.gpu,memory.total,memory.used,memory.free,driver_version,name,gpu_serial,display_active,display_mode,temperature.gpu", "--format=csv,noheader,nounits"], stdout=PIPE)
         stdout, stderror = p.communicate()
+        if (p.returncode != 0):
+            return []
     except:
         return []
     output = stdout.decode('UTF-8')


### PR DESCRIPTION
This fixes the error caused by this [issue](https://github.com/anderskm/gputil/issues/62). the root cause being that nvidia-smi returned the error message directly to the stdout. Now this checks that the call returned the correct success code as stated [here](https://docs.nvidia.com/deploy/nvidia-smi/index.html). If not it will return an empty array.